### PR TITLE
Safe unique ptr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,27 +1,28 @@
 cmake_minimum_required(VERSION 2.8.12)
 
 if(DEFINED EXTERNAL_EXTENSION_DIRECTORIES)
-    add_subdirectory(arrow)
+  add_subdirectory(arrow)
 else()
-    set(TARGET_NAME arrow)
-    project(${TARGET_NAME})
+  set(TARGET_NAME arrow)
+  project(${TARGET_NAME})
 
-    set(EXTENSION_CLASS ${TARGET_NAME}Extension)
-    string(SUBSTRING ${TARGET_NAME} 0 1 FIRST_LETTER)
-    string(TOUPPER ${FIRST_LETTER} FIRST_LETTER)
-    string(REGEX REPLACE "^.(.*)" "${FIRST_LETTER}\\1" EXTENSION_CLASS
-            "${TARGET_NAME}")
+  set(EXTENSION_CLASS ${TARGET_NAME}Extension)
+  string(SUBSTRING ${TARGET_NAME} 0 1 FIRST_LETTER)
+  string(TOUPPER ${FIRST_LETTER} FIRST_LETTER)
+  string(REGEX REPLACE "^.(.*)" "${FIRST_LETTER}\\1" EXTENSION_CLASS
+                       "${TARGET_NAME}")
 
-    cmake_policy(SET CMP0079 NEW)
+  cmake_policy(SET CMP0079 NEW)
 
-    include_directories(${TARGET_NAME}/include)
-    add_compile_definitions(DUCKDB_OUT_OF_TREE)
-    add_compile_definitions(DUCKDB_EXTENSION_CLASS=${EXTENSION_CLASS}Extension)
-    add_compile_definitions(DUCKDB_EXTENSION_HEADER="${TARGET_NAME}_extension.hpp")
+  include_directories(${TARGET_NAME}/include)
+  add_compile_definitions(DUCKDB_OUT_OF_TREE)
+  add_compile_definitions(DUCKDB_EXTENSION_CLASS=${EXTENSION_CLASS}Extension)
+  add_compile_definitions(
+    DUCKDB_EXTENSION_HEADER="${TARGET_NAME}_extension.hpp")
 
-    set(EXTERNAL_EXTENSION_DIRECTORIES ../${TARGET_NAME})
+  set(EXTERNAL_EXTENSION_DIRECTORIES ../${TARGET_NAME})
 
-    add_subdirectory(duckdb)
+  add_subdirectory(duckdb)
 
-    target_link_libraries(unittest ${TARGET_NAME}_extension)
+  target_link_libraries(unittest ${TARGET_NAME}_extension)
 endif()

--- a/arrow/CMakeLists.txt
+++ b/arrow/CMakeLists.txt
@@ -1,66 +1,42 @@
 cmake_minimum_required(VERSION 2.8.12)
 
-if (OSX_BUILD_UNIVERSAL EQUAL 1)
-    set(OSX_UNIVERSAL_FLAG -DCMAKE_OSX_ARCHITECTURES=x86_64$<SEMICOLON>arm64)
+if(OSX_BUILD_UNIVERSAL EQUAL 1)
+  set(OSX_UNIVERSAL_FLAG -DCMAKE_OSX_ARCHITECTURES=x86_64$<SEMICOLON>arm64)
 else()
-    set(OSX_UNIVERSAL_FLAG "")
+  set(OSX_UNIVERSAL_FLAG "")
 endif()
 
 # Building Arrow
 include(ExternalProject)
 ExternalProject_Add(
-        arrow_ep
-        GIT_REPOSITORY "https://github.com/apache/arrow"
-        GIT_TAG ea6875fd2a3ac66547a9a33c5506da94f3ff07f2
-        PREFIX "${CMAKE_BINARY_DIR}/third_party/arrow"
-        INSTALL_DIR "${CMAKE_BINARY_DIR}/third_party/arrow/install"
-        BUILD_BYPRODUCTS
-        <INSTALL_DIR>/lib/libarrow.a
-        CONFIGURE_COMMAND
-            ${CMAKE_COMMAND} -G${CMAKE_GENERATOR}
-            ${OSX_UNIVERSAL_FLAG}
-            -DCMAKE_BUILD_TYPE=Release
-            -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/third_party/arrow/install
-            -DCMAKE_INSTALL_LIBDIR=lib
-            -DARROW_BUILD_STATIC=ON
-            -DARROW_BUILD_SHARED=OFF
-            -DARROW_NO_DEPRECATED_API=ON
-            -DARROW_POSITION_INDEPENDENT_CODE=ON
-            -DARROW_SIMD_LEVEL=NONE
-            -DARROW_ENABLE_TIMING_TESTS=OFF
-            -DARROW_IPC=ON
-            -DARROW_JEMALLOC=OFF
-            -DARROW_DEPENDENCY_SOURCE=BUNDLED
-            -DARROW_VERBOSE_THIRDPARTY_BUILD=OFF
-            -DARROW_DEPENDENCY_USE_SHARED=OFF
-            -DARROW_BOOST_USE_SHARED=OFF
-            -DARROW_BROTLI_USE_SHARED=OFF
-            -DARROW_BZ2_USE_SHARED=OFF
-            -DARROW_GFLAGS_USE_SHARED=OFF
-            -DARROW_GRPC_USE_SHARED=OFF
-            -DARROW_JEMALLOC_USE_SHARED=OFF
-            -DARROW_LZ4_USE_SHARED=OFF
-            -DARROW_OPENSSL_USE_SHARED=OFF
-            -DARROW_PROTOBUF_USE_SHARED=OFF
-            -DARROW_SNAPPY_USE_SHARED=OFF
-            -DARROW_THRIFT_USE_SHARED=OFF
-            -DARROW_UTF8PROC_USE_SHARED=OFF
-            -DARROW_ZSTD_USE_SHARED=OFF
-            -DARROW_USE_GLOG=OFF
-            -DARROW_WITH_BACKTRACE=OFF
-            -DARROW_WITH_OPENTELEMETRY=OFF
-            -DARROW_WITH_BROTLI=OFF
-            -DARROW_WITH_BZ2=OFF
-            -DARROW_WITH_LZ4=OFF
-            -DARROW_WITH_SNAPPY=OFF
-            -DARROW_WITH_ZLIB=OFF
-            -DARROW_WITH_ZSTD=OFF
-            -DARROW_WITH_UCX=OFF
-            -DARROW_WITH_UTF8PROC=OFF
-            -DARROW_WITH_RE2=OFF
-            <SOURCE_DIR>/cpp
-        CMAKE_ARGS -Wno-dev
-        UPDATE_COMMAND "")
+  arrow_ep
+  GIT_REPOSITORY "https://github.com/apache/arrow"
+  GIT_TAG ea6875fd2a3ac66547a9a33c5506da94f3ff07f2
+  PREFIX "${CMAKE_BINARY_DIR}/third_party/arrow"
+  INSTALL_DIR "${CMAKE_BINARY_DIR}/third_party/arrow/install"
+  BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libarrow.a
+  CONFIGURE_COMMAND
+    ${CMAKE_COMMAND} -G${CMAKE_GENERATOR} ${OSX_UNIVERSAL_FLAG}
+    -DCMAKE_BUILD_TYPE=Release
+    -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/third_party/arrow/install
+    -DCMAKE_INSTALL_LIBDIR=lib -DARROW_BUILD_STATIC=ON -DARROW_BUILD_SHARED=OFF
+    -DARROW_NO_DEPRECATED_API=ON -DARROW_POSITION_INDEPENDENT_CODE=ON
+    -DARROW_SIMD_LEVEL=NONE -DARROW_ENABLE_TIMING_TESTS=OFF -DARROW_IPC=ON
+    -DARROW_JEMALLOC=OFF -DARROW_DEPENDENCY_SOURCE=BUNDLED
+    -DARROW_VERBOSE_THIRDPARTY_BUILD=OFF -DARROW_DEPENDENCY_USE_SHARED=OFF
+    -DARROW_BOOST_USE_SHARED=OFF -DARROW_BROTLI_USE_SHARED=OFF
+    -DARROW_BZ2_USE_SHARED=OFF -DARROW_GFLAGS_USE_SHARED=OFF
+    -DARROW_GRPC_USE_SHARED=OFF -DARROW_JEMALLOC_USE_SHARED=OFF
+    -DARROW_LZ4_USE_SHARED=OFF -DARROW_OPENSSL_USE_SHARED=OFF
+    -DARROW_PROTOBUF_USE_SHARED=OFF -DARROW_SNAPPY_USE_SHARED=OFF
+    -DARROW_THRIFT_USE_SHARED=OFF -DARROW_UTF8PROC_USE_SHARED=OFF
+    -DARROW_ZSTD_USE_SHARED=OFF -DARROW_USE_GLOG=OFF -DARROW_WITH_BACKTRACE=OFF
+    -DARROW_WITH_OPENTELEMETRY=OFF -DARROW_WITH_BROTLI=OFF -DARROW_WITH_BZ2=OFF
+    -DARROW_WITH_LZ4=OFF -DARROW_WITH_SNAPPY=OFF -DARROW_WITH_ZLIB=OFF
+    -DARROW_WITH_ZSTD=OFF -DARROW_WITH_UCX=OFF -DARROW_WITH_UTF8PROC=OFF
+    -DARROW_WITH_RE2=OFF <SOURCE_DIR>/cpp
+  CMAKE_ARGS -Wno-dev
+  UPDATE_COMMAND "")
 
 ExternalProject_Get_Property(arrow_ep install_dir)
 set(install_arrow ${install_dir})
@@ -72,7 +48,8 @@ project(${TARGET_NAME})
 include_directories(include)
 include_directories(../..)
 
-set(ARROW_SOURCES arrow_extension.cpp arrow_stream_buffer.cpp arrow_scan_ipc.cpp arrow_to_ipc.cpp)
+set(ARROW_SOURCES arrow_extension.cpp arrow_stream_buffer.cpp
+                  arrow_scan_ipc.cpp arrow_to_ipc.cpp)
 
 add_library(arrow_extension STATIC ${ARROW_SOURCES})
 
@@ -93,11 +70,14 @@ install(
   LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
   ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
 
-# Filthy hack: currently duckdb ci expects extensions to build their loadable extensions to their root build folder
-#              so if we're building from within duckdb, we perform this copy to move the file to the expected location
-# FIXME: DuckDB should provide a neat way for extensions to specify where the loadable_execution will be located
+# Filthy hack: currently duckdb ci expects extensions to build their loadable
+# extensions to their root build folder so if we're building from within duckdb,
+# we perform this copy to move the file to the expected location FIXME: DuckDB
+# should provide a neat way for extensions to specify where the
+# loadable_execution will be located
 add_custom_command(
-    TARGET arrow_loadable_extension POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy
-    ${CMAKE_CURRENT_BINARY_DIR}/arrow.duckdb_extension
+  TARGET arrow_loadable_extension
+  POST_BUILD
+  COMMAND
+    ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/arrow.duckdb_extension
     ${CMAKE_CURRENT_BINARY_DIR}/../)

--- a/arrow/arrow_extension.cpp
+++ b/arrow/arrow_extension.cpp
@@ -17,34 +17,38 @@
 namespace duckdb {
 
 static void LoadInternal(DatabaseInstance &instance) {
-  Connection con(instance);
-  con.BeginTransaction();
-  auto &catalog = Catalog::GetSystemCatalog(*con.context);
+	Connection con(instance);
+	con.BeginTransaction();
+	auto &catalog = Catalog::GetSystemCatalog(*con.context);
 
-  auto to_arrow_fun = ToArrowIPCFunction::GetFunction();
-  CreateTableFunctionInfo to_arrow_ipc_info(to_arrow_fun);
-  catalog.CreateTableFunction(*con.context, &to_arrow_ipc_info);
+	auto to_arrow_fun = ToArrowIPCFunction::GetFunction();
+	CreateTableFunctionInfo to_arrow_ipc_info(to_arrow_fun);
+	catalog.CreateTableFunction(*con.context, &to_arrow_ipc_info);
 
-  auto scan_arrow_fun = ArrowIPCTableFunction::GetFunction();
-  CreateTableFunctionInfo scan_arrow_ipc_info(scan_arrow_fun);
-  catalog.CreateTableFunction(*con.context, &scan_arrow_ipc_info);
+	auto scan_arrow_fun = ArrowIPCTableFunction::GetFunction();
+	CreateTableFunctionInfo scan_arrow_ipc_info(scan_arrow_fun);
+	catalog.CreateTableFunction(*con.context, &scan_arrow_ipc_info);
 
-  con.Commit();
+	con.Commit();
 }
 
-void ArrowExtension::Load(DuckDB &db) { LoadInternal(*db.instance); }
-std::string ArrowExtension::Name() { return "arrow"; }
+void ArrowExtension::Load(DuckDB &db) {
+	LoadInternal(*db.instance);
+}
+std::string ArrowExtension::Name() {
+	return "arrow";
+}
 
 } // namespace duckdb
 
 extern "C" {
 
 DUCKDB_EXTENSION_API void arrow_init(duckdb::DatabaseInstance &db) {
-  LoadInternal(db);
+	LoadInternal(db);
 }
 
 DUCKDB_EXTENSION_API const char *arrow_version() {
-  return duckdb::DuckDB::LibraryVersion();
+	return duckdb::DuckDB::LibraryVersion();
 }
 }
 

--- a/arrow/arrow_extension.cpp
+++ b/arrow/arrow_extension.cpp
@@ -17,38 +17,34 @@
 namespace duckdb {
 
 static void LoadInternal(DatabaseInstance &instance) {
-	Connection con(instance);
-	con.BeginTransaction();
-	auto &catalog = Catalog::GetSystemCatalog(*con.context);
+  Connection con(instance);
+  con.BeginTransaction();
+  auto &catalog = Catalog::GetSystemCatalog(*con.context);
 
-    auto to_arrow_fun = ToArrowIPCFunction::GetFunction();
-	CreateTableFunctionInfo to_arrow_ipc_info(to_arrow_fun);
-	catalog.CreateTableFunction(*con.context, &to_arrow_ipc_info);
+  auto to_arrow_fun = ToArrowIPCFunction::GetFunction();
+  CreateTableFunctionInfo to_arrow_ipc_info(to_arrow_fun);
+  catalog.CreateTableFunction(*con.context, &to_arrow_ipc_info);
 
-    auto scan_arrow_fun = ArrowIPCTableFunction::GetFunction();
-	CreateTableFunctionInfo scan_arrow_ipc_info(scan_arrow_fun);
-	catalog.CreateTableFunction(*con.context, &scan_arrow_ipc_info);
+  auto scan_arrow_fun = ArrowIPCTableFunction::GetFunction();
+  CreateTableFunctionInfo scan_arrow_ipc_info(scan_arrow_fun);
+  catalog.CreateTableFunction(*con.context, &scan_arrow_ipc_info);
 
-	con.Commit();
+  con.Commit();
 }
 
-void ArrowExtension::Load(DuckDB &db) {
-	LoadInternal(*db.instance);
-}
-std::string ArrowExtension::Name() {
-	return "arrow";
-}
+void ArrowExtension::Load(DuckDB &db) { LoadInternal(*db.instance); }
+std::string ArrowExtension::Name() { return "arrow"; }
 
 } // namespace duckdb
 
 extern "C" {
 
 DUCKDB_EXTENSION_API void arrow_init(duckdb::DatabaseInstance &db) {
-	LoadInternal(db);
+  LoadInternal(db);
 }
 
 DUCKDB_EXTENSION_API const char *arrow_version() {
-	return duckdb::DuckDB::LibraryVersion();
+  return duckdb::DuckDB::LibraryVersion();
 }
 }
 

--- a/arrow/arrow_scan_ipc.cpp
+++ b/arrow/arrow_scan_ipc.cpp
@@ -22,7 +22,7 @@ TableFunction ArrowIPCTableFunction::GetFunction() {
 
 unique_ptr <FunctionData> ArrowIPCTableFunction::ArrowScanBind(ClientContext &context, TableFunctionBindInput &input,
                                      vector <LogicalType> &return_types, vector <string> &names) {
-    auto stream_decoder = make_unique<BufferingArrowIPCStreamDecoder>();
+    auto stream_decoder = make_uniq<BufferingArrowIPCStreamDecoder>();
 
     // Decode buffer ptr list
     auto buffer_ptr_list = ListValue::GetChildren(input.inputs[0]);
@@ -47,7 +47,7 @@ unique_ptr <FunctionData> ArrowIPCTableFunction::ArrowScanBind(ClientContext &co
     auto stream_factory_ptr = (uintptr_t) & stream_decoder->buffer();
     auto stream_factory_produce = (stream_factory_produce_t) & ArrowIPCStreamBufferReader::CreateStream;
     auto stream_factory_get_schema = (stream_factory_get_schema_t) & ArrowIPCStreamBufferReader::GetSchema;
-    auto res = make_unique<ArrowIPCScanFunctionData>(stream_factory_produce, stream_factory_ptr);
+    auto res = make_uniq<ArrowIPCScanFunctionData>(stream_factory_produce, stream_factory_ptr);
 
     // Store decoder
     res->stream_decoder = std::move(stream_decoder);
@@ -62,7 +62,7 @@ unique_ptr <FunctionData> ArrowIPCTableFunction::ArrowScanBind(ClientContext &co
         }
         if (schema.dictionary) {
             res->arrow_convert_data[col_idx] =
-                    make_unique<ArrowConvertData>(GetArrowLogicalType(schema, res->arrow_convert_data, col_idx));
+                    make_uniq<ArrowConvertData>(GetArrowLogicalType(schema, res->arrow_convert_data, col_idx));
             return_types.emplace_back(GetArrowLogicalType(*schema.dictionary, res->arrow_convert_data, col_idx));
         } else {
             return_types.emplace_back(GetArrowLogicalType(schema, res->arrow_convert_data, col_idx));

--- a/arrow/arrow_scan_ipc.cpp
+++ b/arrow/arrow_scan_ipc.cpp
@@ -75,7 +75,7 @@ unique_ptr <FunctionData> ArrowIPCTableFunction::ArrowScanBind(ClientContext &co
         names.push_back(name);
     }
     ArrowTableFunction::RenameArrowColumns(names);
-    return move(res);
+    return std::move(res);
 }
 
 // TODO: cleanup: only difference is the ArrowToDuckDB call

--- a/arrow/arrow_stream_buffer.cpp
+++ b/arrow/arrow_stream_buffer.cpp
@@ -7,101 +7,89 @@
 namespace duckdb {
 
 /// Constructor
-ArrowIPCStreamBuffer::ArrowIPCStreamBuffer()
-    : schema_(nullptr), batches_(), is_eos_(false) {}
+ArrowIPCStreamBuffer::ArrowIPCStreamBuffer() : schema_(nullptr), batches_(), is_eos_(false) {
+}
 /// Decoded a schema
-arrow::Status
-ArrowIPCStreamBuffer::OnSchemaDecoded(std::shared_ptr<arrow::Schema> s) {
-  schema_ = s;
-  return arrow::Status::OK();
+arrow::Status ArrowIPCStreamBuffer::OnSchemaDecoded(std::shared_ptr<arrow::Schema> s) {
+	schema_ = s;
+	return arrow::Status::OK();
 }
 /// Decoded a record batch
-arrow::Status ArrowIPCStreamBuffer::OnRecordBatchDecoded(
-    std::shared_ptr<arrow::RecordBatch> batch) {
-  batches_.push_back(batch);
-  return arrow::Status::OK();
+arrow::Status ArrowIPCStreamBuffer::OnRecordBatchDecoded(std::shared_ptr<arrow::RecordBatch> batch) {
+	batches_.push_back(batch);
+	return arrow::Status::OK();
 }
 /// Reached end of stream
 arrow::Status ArrowIPCStreamBuffer::OnEOS() {
-  is_eos_ = true;
-  return arrow::Status::OK();
+	is_eos_ = true;
+	return arrow::Status::OK();
 }
 
 /// Constructor
-ArrowIPCStreamBufferReader::ArrowIPCStreamBufferReader(
-    std::shared_ptr<ArrowIPCStreamBuffer> buffer)
-    : buffer_(buffer), next_batch_id_(0) {}
+ArrowIPCStreamBufferReader::ArrowIPCStreamBufferReader(std::shared_ptr<ArrowIPCStreamBuffer> buffer)
+    : buffer_(buffer), next_batch_id_(0) {
+}
 
 /// Get the schema
 std::shared_ptr<arrow::Schema> ArrowIPCStreamBufferReader::schema() const {
-  return buffer_->schema();
+	return buffer_->schema();
 }
 /// Read the next record batch in the stream. Return null for batch when
 /// reaching end of stream
-arrow::Status ArrowIPCStreamBufferReader::ReadNext(
-    std::shared_ptr<arrow::RecordBatch> *batch) {
-  if (next_batch_id_ >= buffer_->batches().size()) {
-    *batch = nullptr;
-    return arrow::Status::OK();
-  }
-  *batch = buffer_->batches()[next_batch_id_++];
-  return arrow::Status::OK();
+arrow::Status ArrowIPCStreamBufferReader::ReadNext(std::shared_ptr<arrow::RecordBatch> *batch) {
+	if (next_batch_id_ >= buffer_->batches().size()) {
+		*batch = nullptr;
+		return arrow::Status::OK();
+	}
+	*batch = buffer_->batches()[next_batch_id_++];
+	return arrow::Status::OK();
 }
 
 /// Arrow array stream factory function
 std::unique_ptr<duckdb::ArrowArrayStreamWrapper>
-ArrowIPCStreamBufferReader::CreateStream(uintptr_t buffer_ptr,
-                                         ArrowStreamParameters &parameters) {
-  assert(buffer_ptr != 0);
-  auto buffer =
-      reinterpret_cast<std::shared_ptr<ArrowIPCStreamBuffer> *>(buffer_ptr);
-  auto reader = std::make_shared<ArrowIPCStreamBufferReader>(*buffer);
+ArrowIPCStreamBufferReader::CreateStream(uintptr_t buffer_ptr, ArrowStreamParameters &parameters) {
+	assert(buffer_ptr != 0);
+	auto buffer = reinterpret_cast<std::shared_ptr<ArrowIPCStreamBuffer> *>(buffer_ptr);
+	auto reader = std::make_shared<ArrowIPCStreamBufferReader>(*buffer);
 
-  // Create arrow stream
-  auto stream_wrapper = duckdb::make_uniq<duckdb::ArrowArrayStreamWrapper>();
-  stream_wrapper->arrow_array_stream.release = nullptr;
-  auto maybe_ok = arrow::ExportRecordBatchReader(
-      reader, &stream_wrapper->arrow_array_stream);
-  if (!maybe_ok.ok()) {
-    if (stream_wrapper->arrow_array_stream.release) {
-      stream_wrapper->arrow_array_stream.release(
-          &stream_wrapper->arrow_array_stream);
-    }
-    return nullptr;
-  }
+	// Create arrow stream
+	auto stream_wrapper = duckdb::make_uniq<duckdb::ArrowArrayStreamWrapper>();
+	stream_wrapper->arrow_array_stream.release = nullptr;
+	auto maybe_ok = arrow::ExportRecordBatchReader(reader, &stream_wrapper->arrow_array_stream);
+	if (!maybe_ok.ok()) {
+		if (stream_wrapper->arrow_array_stream.release) {
+			stream_wrapper->arrow_array_stream.release(&stream_wrapper->arrow_array_stream);
+		}
+		return nullptr;
+	}
 
-  // Release the stream
-  return stream_wrapper;
+	// Release the stream
+	return stream_wrapper;
 }
 
-void ArrowIPCStreamBufferReader::GetSchema(uintptr_t buffer_ptr,
-                                           duckdb::ArrowSchemaWrapper &schema) {
-  assert(buffer_ptr != 0);
-  auto buffer =
-      reinterpret_cast<std::shared_ptr<ArrowIPCStreamBuffer> *>(buffer_ptr);
-  auto reader = std::make_shared<ArrowIPCStreamBufferReader>(*buffer);
+void ArrowIPCStreamBufferReader::GetSchema(uintptr_t buffer_ptr, duckdb::ArrowSchemaWrapper &schema) {
+	assert(buffer_ptr != 0);
+	auto buffer = reinterpret_cast<std::shared_ptr<ArrowIPCStreamBuffer> *>(buffer_ptr);
+	auto reader = std::make_shared<ArrowIPCStreamBufferReader>(*buffer);
 
-  // Create arrow stream
-  auto stream_wrapper = duckdb::make_uniq<duckdb::ArrowArrayStreamWrapper>();
-  stream_wrapper->arrow_array_stream.release = nullptr;
-  auto maybe_ok = arrow::ExportRecordBatchReader(
-      reader, &stream_wrapper->arrow_array_stream);
-  if (!maybe_ok.ok()) {
-    if (stream_wrapper->arrow_array_stream.release) {
-      stream_wrapper->arrow_array_stream.release(
-          &stream_wrapper->arrow_array_stream);
-    }
-    return;
-  }
+	// Create arrow stream
+	auto stream_wrapper = duckdb::make_uniq<duckdb::ArrowArrayStreamWrapper>();
+	stream_wrapper->arrow_array_stream.release = nullptr;
+	auto maybe_ok = arrow::ExportRecordBatchReader(reader, &stream_wrapper->arrow_array_stream);
+	if (!maybe_ok.ok()) {
+		if (stream_wrapper->arrow_array_stream.release) {
+			stream_wrapper->arrow_array_stream.release(&stream_wrapper->arrow_array_stream);
+		}
+		return;
+	}
 
-  // Pass ownership to caller
-  stream_wrapper->arrow_array_stream.get_schema(
-      &stream_wrapper->arrow_array_stream, &schema.arrow_schema);
+	// Pass ownership to caller
+	stream_wrapper->arrow_array_stream.get_schema(&stream_wrapper->arrow_array_stream, &schema.arrow_schema);
 }
 
 /// Constructor
-BufferingArrowIPCStreamDecoder::BufferingArrowIPCStreamDecoder(
-    std::shared_ptr<ArrowIPCStreamBuffer> buffer)
-    : arrow::ipc::StreamDecoder(buffer), buffer_(buffer) {}
+BufferingArrowIPCStreamDecoder::BufferingArrowIPCStreamDecoder(std::shared_ptr<ArrowIPCStreamBuffer> buffer)
+    : arrow::ipc::StreamDecoder(buffer), buffer_(buffer) {
+}
 
 } // namespace duckdb

--- a/arrow/arrow_stream_buffer.cpp
+++ b/arrow/arrow_stream_buffer.cpp
@@ -7,88 +7,101 @@
 namespace duckdb {
 
 /// Constructor
-ArrowIPCStreamBuffer::ArrowIPCStreamBuffer() : schema_(nullptr), batches_(), is_eos_(false) {
-}
+ArrowIPCStreamBuffer::ArrowIPCStreamBuffer()
+    : schema_(nullptr), batches_(), is_eos_(false) {}
 /// Decoded a schema
-arrow::Status ArrowIPCStreamBuffer::OnSchemaDecoded(std::shared_ptr<arrow::Schema> s) {
-	schema_ = s;
-	return arrow::Status::OK();
+arrow::Status
+ArrowIPCStreamBuffer::OnSchemaDecoded(std::shared_ptr<arrow::Schema> s) {
+  schema_ = s;
+  return arrow::Status::OK();
 }
 /// Decoded a record batch
-arrow::Status ArrowIPCStreamBuffer::OnRecordBatchDecoded(std::shared_ptr<arrow::RecordBatch> batch) {
-	batches_.push_back(batch);
-	return arrow::Status::OK();
+arrow::Status ArrowIPCStreamBuffer::OnRecordBatchDecoded(
+    std::shared_ptr<arrow::RecordBatch> batch) {
+  batches_.push_back(batch);
+  return arrow::Status::OK();
 }
 /// Reached end of stream
 arrow::Status ArrowIPCStreamBuffer::OnEOS() {
-	is_eos_ = true;
-	return arrow::Status::OK();
+  is_eos_ = true;
+  return arrow::Status::OK();
 }
 
 /// Constructor
-ArrowIPCStreamBufferReader::ArrowIPCStreamBufferReader(std::shared_ptr<ArrowIPCStreamBuffer> buffer)
-    : buffer_(buffer), next_batch_id_(0) {
-}
+ArrowIPCStreamBufferReader::ArrowIPCStreamBufferReader(
+    std::shared_ptr<ArrowIPCStreamBuffer> buffer)
+    : buffer_(buffer), next_batch_id_(0) {}
 
 /// Get the schema
 std::shared_ptr<arrow::Schema> ArrowIPCStreamBufferReader::schema() const {
-	return buffer_->schema();
+  return buffer_->schema();
 }
-/// Read the next record batch in the stream. Return null for batch when reaching end of stream
-arrow::Status ArrowIPCStreamBufferReader::ReadNext(std::shared_ptr<arrow::RecordBatch> *batch) {
-	if (next_batch_id_ >= buffer_->batches().size()) {
-		*batch = nullptr;
-		return arrow::Status::OK();
-	}
-	*batch = buffer_->batches()[next_batch_id_++];
-	return arrow::Status::OK();
+/// Read the next record batch in the stream. Return null for batch when
+/// reaching end of stream
+arrow::Status ArrowIPCStreamBufferReader::ReadNext(
+    std::shared_ptr<arrow::RecordBatch> *batch) {
+  if (next_batch_id_ >= buffer_->batches().size()) {
+    *batch = nullptr;
+    return arrow::Status::OK();
+  }
+  *batch = buffer_->batches()[next_batch_id_++];
+  return arrow::Status::OK();
 }
 
 /// Arrow array stream factory function
 std::unique_ptr<duckdb::ArrowArrayStreamWrapper>
-ArrowIPCStreamBufferReader::CreateStream(uintptr_t buffer_ptr, ArrowStreamParameters &parameters) {
-	assert(buffer_ptr != 0);
-	auto buffer = reinterpret_cast<std::shared_ptr<ArrowIPCStreamBuffer> *>(buffer_ptr);
-	auto reader = std::make_shared<ArrowIPCStreamBufferReader>(*buffer);
+ArrowIPCStreamBufferReader::CreateStream(uintptr_t buffer_ptr,
+                                         ArrowStreamParameters &parameters) {
+  assert(buffer_ptr != 0);
+  auto buffer =
+      reinterpret_cast<std::shared_ptr<ArrowIPCStreamBuffer> *>(buffer_ptr);
+  auto reader = std::make_shared<ArrowIPCStreamBufferReader>(*buffer);
 
-	// Create arrow stream
-	auto stream_wrapper = duckdb::make_unique<duckdb::ArrowArrayStreamWrapper>();
-	stream_wrapper->arrow_array_stream.release = nullptr;
-	auto maybe_ok = arrow::ExportRecordBatchReader(reader, &stream_wrapper->arrow_array_stream);
-	if (!maybe_ok.ok()) {
-		if (stream_wrapper->arrow_array_stream.release) {
-			stream_wrapper->arrow_array_stream.release(&stream_wrapper->arrow_array_stream);
-		}
-		return nullptr;
-	}
+  // Create arrow stream
+  auto stream_wrapper = duckdb::make_uniq<duckdb::ArrowArrayStreamWrapper>();
+  stream_wrapper->arrow_array_stream.release = nullptr;
+  auto maybe_ok = arrow::ExportRecordBatchReader(
+      reader, &stream_wrapper->arrow_array_stream);
+  if (!maybe_ok.ok()) {
+    if (stream_wrapper->arrow_array_stream.release) {
+      stream_wrapper->arrow_array_stream.release(
+          &stream_wrapper->arrow_array_stream);
+    }
+    return nullptr;
+  }
 
-	// Release the stream
-	return stream_wrapper;
+  // Release the stream
+  return stream_wrapper;
 }
 
-void ArrowIPCStreamBufferReader::GetSchema(uintptr_t buffer_ptr, duckdb::ArrowSchemaWrapper &schema) {
-	assert(buffer_ptr != 0);
-	auto buffer = reinterpret_cast<std::shared_ptr<ArrowIPCStreamBuffer> *>(buffer_ptr);
-	auto reader = std::make_shared<ArrowIPCStreamBufferReader>(*buffer);
+void ArrowIPCStreamBufferReader::GetSchema(uintptr_t buffer_ptr,
+                                           duckdb::ArrowSchemaWrapper &schema) {
+  assert(buffer_ptr != 0);
+  auto buffer =
+      reinterpret_cast<std::shared_ptr<ArrowIPCStreamBuffer> *>(buffer_ptr);
+  auto reader = std::make_shared<ArrowIPCStreamBufferReader>(*buffer);
 
-	// Create arrow stream
-	auto stream_wrapper = duckdb::make_unique<duckdb::ArrowArrayStreamWrapper>();
-	stream_wrapper->arrow_array_stream.release = nullptr;
-	auto maybe_ok = arrow::ExportRecordBatchReader(reader, &stream_wrapper->arrow_array_stream);
-	if (!maybe_ok.ok()) {
-		if (stream_wrapper->arrow_array_stream.release) {
-			stream_wrapper->arrow_array_stream.release(&stream_wrapper->arrow_array_stream);
-		}
-		return;
-	}
+  // Create arrow stream
+  auto stream_wrapper = duckdb::make_uniq<duckdb::ArrowArrayStreamWrapper>();
+  stream_wrapper->arrow_array_stream.release = nullptr;
+  auto maybe_ok = arrow::ExportRecordBatchReader(
+      reader, &stream_wrapper->arrow_array_stream);
+  if (!maybe_ok.ok()) {
+    if (stream_wrapper->arrow_array_stream.release) {
+      stream_wrapper->arrow_array_stream.release(
+          &stream_wrapper->arrow_array_stream);
+    }
+    return;
+  }
 
-	// Pass ownership to caller
-	stream_wrapper->arrow_array_stream.get_schema(&stream_wrapper->arrow_array_stream, &schema.arrow_schema);
+  // Pass ownership to caller
+  stream_wrapper->arrow_array_stream.get_schema(
+      &stream_wrapper->arrow_array_stream, &schema.arrow_schema);
 }
 
 /// Constructor
-BufferingArrowIPCStreamDecoder::BufferingArrowIPCStreamDecoder(std::shared_ptr<ArrowIPCStreamBuffer> buffer)
-    : arrow::ipc::StreamDecoder(buffer), buffer_(buffer) {
-}
+BufferingArrowIPCStreamDecoder::BufferingArrowIPCStreamDecoder(
+    std::shared_ptr<ArrowIPCStreamBuffer> buffer)
+    : arrow::ipc::StreamDecoder(buffer), buffer_(buffer) {}
 
 } // namespace duckdb

--- a/arrow/arrow_to_ipc.cpp
+++ b/arrow/arrow_to_ipc.cpp
@@ -75,7 +75,7 @@ unique_ptr<FunctionData> ToArrowIPCFunction::Bind(ClientContext &context, TableF
     ArrowConverter::ToArrowSchema(&schema, input.input_table_types, input.input_table_names, tz);
     result->schema = arrow::ImportSchema(&schema).ValueOrDie();
 
-    return move(result);
+    return std::move(result);
 }
 
 OperatorResultType ToArrowIPCFunction::Function(ExecutionContext &context, TableFunctionInput &data_p, DataChunk &input,

--- a/arrow/arrow_to_ipc.cpp
+++ b/arrow/arrow_to_ipc.cpp
@@ -49,17 +49,17 @@ struct ToArrowIpcLocalState : public LocalTableFunctionState {
 
 unique_ptr<LocalTableFunctionState> ToArrowIPCFunction::InitLocal(ExecutionContext &context, TableFunctionInitInput &input,
                                                                GlobalTableFunctionState *global_state) {
-    return make_unique<ToArrowIpcLocalState>();
+    return make_uniq<ToArrowIpcLocalState>();
 }
 
 unique_ptr<GlobalTableFunctionState> ToArrowIPCFunction::InitGlobal(ClientContext &context,
                                                                  TableFunctionInitInput &input) {
-    return make_unique<ToArrowIpcGlobalState>();
+    return make_uniq<ToArrowIpcGlobalState>();
 }
 
 unique_ptr<FunctionData> ToArrowIPCFunction::Bind(ClientContext &context, TableFunctionBindInput &input,
                                                vector<LogicalType> &return_types, vector<string> &names) {
-    auto result = make_unique<ToArrowIpcFunctionData>();
+    auto result = make_uniq<ToArrowIpcFunctionData>();
 
     result->chunk_size = DEFAULT_CHUNK_SIZE * STANDARD_VECTOR_SIZE;
 
@@ -105,7 +105,7 @@ OperatorResultType ToArrowIPCFunction::Function(ExecutionContext &context, Table
         output.data[1].SetValue(0, Value::BOOLEAN(1));
     } else {
         if (!local_state.appender) {
-            local_state.appender = make_unique<ArrowAppender>(input.GetTypes(), data.chunk_size);
+            local_state.appender = make_uniq<ArrowAppender>(input.GetTypes(), data.chunk_size);
         }
 
         // Append input chunk

--- a/arrow/include/arrow_to_ipc.hpp
+++ b/arrow/include/arrow_to_ipc.hpp
@@ -8,7 +8,7 @@ namespace duckdb {
 class ArrowStringVectorBuffer : public VectorBuffer {
 public:
     explicit ArrowStringVectorBuffer(std::shared_ptr <arrow::Buffer> buffer_p)
-            : VectorBuffer(VectorBufferType::OPAQUE_BUFFER), buffer(move(buffer_p)) {
+            : VectorBuffer(VectorBufferType::OPAQUE_BUFFER), buffer(std::move(buffer_p)) {
     }
 
 private:


### PR DESCRIPTION
This PR is made in preparation of migrating DuckDB to use it's own `unique_ptr` implementation
Removing the use of `std::make_unique` and changing it to `duckdb::make_uniq`
`make_unique` -> `make_uniq` is done to avoid clashing with the std namespace and having to explicitly qualify every call.